### PR TITLE
DDNA.initialise took 10 seconds 

### DIFF
--- a/library/src/main/java/com/deltadna/android/sdk/Product.java
+++ b/library/src/main/java/com/deltadna/android/sdk/Product.java
@@ -151,7 +151,11 @@ public class Product<T extends Product<T>> implements JsonParams {
         Preconditions.checkArg(
                 !TextUtils.isEmpty(code),
                 "code cannot be null or empty");
-        
+
+        if (ddna.getIso4217() == null) {
+            ddna.readIso4217();
+        }
+
         if (ddna.getIso4217().containsKey(code)) {
             return new Float(value * Math.pow(10, ddna.getIso4217().get(code)))
                     .intValue();


### PR DESCRIPTION
- Bugfix: DDNA initialize took 10 seconds because of iso4217 currency resource read

Solve the five to ten seconds spent on reading xml iso resource file, xpath is like evil but making it async 

Best from italy

Tobia Caneschi
tobia.caneschi@gmail.com
